### PR TITLE
Bugfix flow restart service

### DIFF
--- a/content/io/cloudslang/base/os/linux/restart_service.sl
+++ b/content/io/cloudslang/base/os/linux/restart_service.sl
@@ -52,7 +52,7 @@ flow:
             - port:
                 required: false
             - sudo_command: "'echo -e ' + password + ' | sudo -S ' if bool(sudo_user) else ''"
-            - command: "sudo_command + 'service ' + service_name + ' restart'"
+            - command: "sudo_command + 'service ' + service_name + ' restart' + ' && echo CMD_SUCCESS'"
             - username
             - password:
                 required: False
@@ -68,7 +68,7 @@ flow:
         do:
           strings.string_occurrence_counter:
             - string_in_which_to_search: standard_out
-            - string_to_find: "'done'"
+            - string_to_find: "'CMD_SUCCESS'"
         navigate:
           SUCCESS: SUCCESS
           FAILURE: FAILURE

--- a/content/io/cloudslang/base/os/linux/restart_service.sl
+++ b/content/io/cloudslang/base/os/linux/restart_service.sl
@@ -13,6 +13,7 @@
 #       - username - username to connect as
 #       - password - password of user
 #       - service_name - linux service name to be restarted
+#       - sudo_user - optional - 'true' or 'false' whether to execute the command on behalf of username with sudo. Default: false
 #       - privateKeyFile - optional - path to the private key file
 #
 # Results:

--- a/content/io/cloudslang/base/os/linux/restart_service.sl
+++ b/content/io/cloudslang/base/os/linux/restart_service.sl
@@ -66,11 +66,11 @@ flow:
     - check_result:
         do:
           strings.string_occurrence_counter:
-            - string_in_which_to_search: standard_err
-            - string_to_find: service_name
+            - string_in_which_to_search: standard_out
+            - string_to_find: "'done'"
         navigate:
-          SUCCESS: FAILURE
-          FAILURE: SUCCESS
+          SUCCESS: SUCCESS
+          FAILURE: FAILURE
 
   outputs:
     - standard_err


### PR DESCRIPTION

1. Handling of errors/success isn't correctly detecting the actual status of the service restart command. I altered it to accommodate the real status when working in Linux environments.
2. Updated documentation for the flow
