### PR TITLE
Feature/git reset flow (including tests)

### DIFF
--- a/content/io/cloudslang/git/git_reset.sl
+++ b/content/io/cloudslang/git/git_reset.sl
@@ -52,7 +52,7 @@ flow:
         required: false
   
   workflow:
-    - git_clone:
+    - git_reset:
         do:
           ssh.ssh_flow:
             - host

--- a/content/io/cloudslang/git/git_reset.sl
+++ b/content/io/cloudslang/git/git_reset.sl
@@ -1,0 +1,83 @@
+# (c) Copyright 2015 Liran Tal
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+# The Apache License is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+####################################################
+# This flow performs a git reset on a git directory to clean it up
+#
+#   Inputs:
+#       - host - hostname or IP address
+#       - port - optional - port number for running the command - Default: 22
+#       - username - username to connect as
+#       - password - password of user
+#       - sudo_user - true or false, whether the command should execute using sudo
+#       - git_reset_target - the SHA you want to reset the branch to - Defaults: HEAD
+#       - git_repository_localdir - the target directory where a git repository exists and git_branch should be checked out to - Default: /tmp/repo.git
+#       - privateKeyFile - the absolute path to the private key file
+#
+# Results:
+#  SUCCESS: git repository successfully cleaned up using git reset
+#  FAILURE: an error when trying to clone a git repository
+#
+####################################################
+namespace: io.cloudslang.git
+
+imports:
+  ssh: io.cloudslang.base.remote_command_execution.ssh
+  strings: io.cloudslang.base.strings
+
+flow:
+  name: git_reset
+
+  inputs:
+    - host
+    - port:
+        required: false
+    - username
+    - password:
+        required: false
+    - git_repository_localdir:
+        default: "'/tmp/repo.git'"
+        required: true
+    - git_reset_target:
+        default: "'HEAD'"
+        required: false
+    - sudo_user:
+        default: false
+        required: false
+    - privateKeyFile:
+        required: false
+  
+  workflow:
+    - git_clone:
+        do:
+          ssh.ssh_flow:
+            - host
+            - port:
+                required: false
+            - sudo_command: "'echo ' + password + ' | sudo -S ' if bool(sudo_user) else ''"
+            - git_reset: "' && git reset --hard ' + git_reset_target "
+            - command: "sudo_command + ' cd ' + git_repository_localdir + git_reset + ' && echo GIT_SUCCESS'"
+            - username
+            - password:
+                required: false
+            - privateKeyFile:
+                  required: false
+        publish:
+          - standard_err
+          - standard_out
+          - command
+
+    - check_result:
+        do:
+          strings.string_occurrence_counter:
+            - string_in_which_to_search: standard_out
+            - string_to_find: "'GIT_SUCCESS'"
+
+  outputs:
+    - standard_err
+    - standard_out
+    - command

--- a/content/io/cloudslang/git/git_reset.sl
+++ b/content/io/cloudslang/git/git_reset.sl
@@ -10,7 +10,7 @@
 #
 #   Inputs:
 #       - host - hostname or IP address
-#       - port - optional - port number for running the command - Default: 22
+#       - port - optional - port number for running the command
 #       - username - username to connect as
 #       - password - password of user
 #       - sudo_user - true or false, whether the command should execute using sudo

--- a/test/io/cloudslang/git/git_clone_repository.inputs.yaml
+++ b/test/io/cloudslang/git/git_clone_repository.inputs.yaml
@@ -16,6 +16,7 @@ testGitCloneRepository:
     - git_repository_localdir: "/tmp/cloud-slang-content"
     - git_branch: "master"
     - git_pull_remote: "origin"
+    - git_reset_target: "d4a770d3ffa6906f58e1f45a304fc285f635fa0a"
     - sudo_user: False
   description: Test that git is successfully able to clone a remote repository and pull code
   testFlowPath: io.cloudslang.git.test_git_flow

--- a/test/io/cloudslang/git/test_git_flow.sl
+++ b/test/io/cloudslang/git/test_git_flow.sl
@@ -23,6 +23,7 @@ flow:
     - git_repository_localdir
     - git_pull_remote
     - git_branch
+    - git_reset_target
   workflow:
     - clone_a_git_repository:
         do:
@@ -48,8 +49,23 @@ flow:
             - git_branch
             - git_repository_localdir: git_repository_localdir
         navigate:
-          SUCCESS: git_cleanup
+          SUCCESS: reset_git_branch
           FAILURE: CHECKOUTFAILURE
+        publish:
+          - standard_out
+
+    - reset_git_branch:
+        do:
+          git.git_reset:
+            - host
+            - port
+            - username
+            - password
+            - git_reset_target
+            - git_repository_localdir: git_repository_localdir
+        navigate:
+          SUCCESS: git_cleanup
+          FAILURE: RESETFAILURE
         publish:
           - standard_out
 
@@ -77,3 +93,4 @@ flow:
     - CLONEFAILURE
     - CHECKOUTFAILURE
     - CLEANUPFAILURE
+    - RESETFAILURE

--- a/test/io/cloudslang/git/test_git_flow.sl
+++ b/test/io/cloudslang/git/test_git_flow.sl
@@ -47,7 +47,7 @@ flow:
             - password
             - git_pull_remote
             - git_branch
-            - git_repository_localdir: git_repository_localdir
+            - git_repository_localdir
         navigate:
           SUCCESS: reset_git_branch
           FAILURE: CHECKOUTFAILURE
@@ -62,7 +62,7 @@ flow:
             - username
             - password
             - git_reset_target
-            - git_repository_localdir: git_repository_localdir
+            - git_repository_localdir
         navigate:
           SUCCESS: git_cleanup
           FAILURE: RESETFAILURE


### PR DESCRIPTION
Adding a new Git flow content - git_reset which resets a git working directory to HEAD or given SHA.

1. adding a git reset command to the git content flow
2. updating the git test flow with the new git reset command which will reset the cloned repository to a specific SHA hash