### PR TITLE
Bugfix - missing closing quote in git_checkout_branch flow

### DIFF
--- a/content/io/cloudslang/git/git_checkout_branch.sl
+++ b/content/io/cloudslang/git/git_checkout_branch.sl
@@ -46,7 +46,7 @@ flow:
         default: "'/tmp/repo.git'"
         required: true
     - git_pull_remote:
-        default: "'origin"
+        default: "'origin'"
         required: false
     - sudo_user:
         default: false


### PR DESCRIPTION
fixing a bug in git_checkout_branch workflow for the gill_pull_remote variable which misses a closing quote on the default declartion option