### PR TITLE
Docker containers folder - doc review

### DIFF
--- a/content/io/cloudslang/docker/containers/clear_container.sl
+++ b/content/io/cloudslang/docker/containers/clear_container.sl
@@ -19,9 +19,6 @@
 #   - port - optional - SSH port
 # Outputs:
 #   - error_message - error message of the operation that failed
-# Results:
-#   - SUCCESS - successful
-#   - FAILURE - otherwise
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/clear_container.sl
+++ b/content/io/cloudslang/docker/containers/clear_container.sl
@@ -10,12 +10,13 @@
 #
 # Inputs:
 #   - container_id - ID of the container to be deleted
-#   - docker_options - optional - options for the docker environment
+#   - docker_options - optional - options for the Docker environment
 #                               - from the construct: docker [OPTIONS] COMMAND [arg...]
 #   - docker_host - Docker machine host
 #   - docker_username - Docker machine username
 #   - docker_password - optional - Docker machine password
 #   - private_key_file - optional - path to private key file
+#   - port - optional - SSH port
 # Outputs:
 #   - error_message - error message of the operation that failed
 # Results:

--- a/content/io/cloudslang/docker/containers/clear_containers.sl
+++ b/content/io/cloudslang/docker/containers/clear_containers.sl
@@ -6,7 +6,7 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 ####################################################
-# Deletes all Docker images and containers from Docker Host.
+# Deletes all Docker images and containers from a Docker Host.
 #
 # Inputs:
 #   - docker_host - Docker machine host

--- a/content/io/cloudslang/docker/containers/delete_container.sl
+++ b/content/io/cloudslang/docker/containers/delete_container.sl
@@ -107,7 +107,3 @@ flow:
   outputs:
     - result
     - error_message: ${standard_err}
-
-  results:
-    - SUCCESS
-    - FAILURE

--- a/content/io/cloudslang/docker/containers/delete_container.sl
+++ b/content/io/cloudslang/docker/containers/delete_container.sl
@@ -52,7 +52,8 @@ flow:
         overridable: false
     - cmd_params:
         required: false
-    - params: ${cmd_params + ' ' if bool(cmd_params) else ''}
+    - params:
+        default: ${cmd_params + ' ' if bool(cmd_params) else ''}
         overridable: false
     - host
     - port:
@@ -105,7 +106,7 @@ flow:
           FAIL_VALIDATE_SSH: FAILURE
   outputs:
     - result
-    - standard_err
+    - error_message: ${standard_err}
 
   results:
     - SUCCESS

--- a/content/io/cloudslang/docker/containers/delete_container.sl
+++ b/content/io/cloudslang/docker/containers/delete_container.sl
@@ -53,6 +53,7 @@ flow:
     - cmd_params:
         required: false
     - params: ${cmd_params + ' ' if bool(cmd_params) else ''}
+        overridable: false
     - host
     - port:
         required: false

--- a/content/io/cloudslang/docker/containers/delete_container.sl
+++ b/content/io/cloudslang/docker/containers/delete_container.sl
@@ -12,23 +12,21 @@
 #   - container_id - ID of the container to be deleted
 #   - docker_options - optional - options for the docker environment
 #                               - from the construct: docker [OPTIONS] COMMAND [arg...]
-#   - cmdParams - optional - command parameters - Default: none
+#   - cmd_params - optional - command parameters
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username - Docker machine username
 #   - password - optional - Docker machine password
 #   - private_key_file - optional - absolute path to private key file
-#   - arguments - optional - arguments to pass to command - Default: none
+#   - arguments - optional - arguments to pass to command
 #   - character_set - optional - character encoding used for input stream encoding from target machine
-#                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8' - Default: 'UTF-8'
+#                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8'
 #   - pty - optional - whether to use PTY
 #                    - Valid: true, false
-#                    - Default: false
-#   - timeout - optional - time in milliseconds to wait for the command to complete - Default: '90000'
+#   - timeout - optional - time in milliseconds to wait for the command to complete
 #   - close_session - optional - if 'false' SSH session will be cached for future calls during the life of the flow,
 #                                if 'true' the SSH session used will be closed;
 #                              - Valid: true, false
-#                              - Default: false
 #   - agent_forwarding - optional - the sessionObject that holds the connection if the close session is false
 # Outputs:
 #   - result - ID of the container that was deleted

--- a/content/io/cloudslang/docker/containers/examples/create_db_container.sl
+++ b/content/io/cloudslang/docker/containers/examples/create_db_container.sl
@@ -21,9 +21,6 @@
 # Outputs:
 #   - db_IP - IP of newly created container
 #   - error_message - error message of failed operation
-# Results:
-#   - SUCCESS - successful
-#   - FAILURE - otherwise
 ####################################################
 namespace: io.cloudslang.docker.containers.examples
 

--- a/content/io/cloudslang/docker/containers/examples/demo_clear_containers_wrapper.sl
+++ b/content/io/cloudslang/docker/containers/examples/demo_clear_containers_wrapper.sl
@@ -18,9 +18,6 @@
 #   - private_key_file - optional - path to private key file
 # Outputs:
 #   - error_message - error message
-# Results:
-#   - SUCCESS
-#   - FAILURE
 ####################################################
 
 namespace: io.cloudslang.docker.containers.examples
@@ -66,6 +63,3 @@ flow:
           - error_message
   outputs:
     - error_message
-  results:
-    - SUCCESS
-    - FAILURE

--- a/content/io/cloudslang/docker/containers/examples/demo_clear_containers_wrapper.sl
+++ b/content/io/cloudslang/docker/containers/examples/demo_clear_containers_wrapper.sl
@@ -12,6 +12,7 @@
 #   - db_container_id - ID of the DB container
 #   - linked_container_id - ID of the linked container
 #   - docker_host - Docker machine host
+#   - port - optional - SSH port
 #   - docker_username - Docker machine username
 #   - docker_password - optional - Docker machine host password
 #   - private_key_file - optional - path to private key file

--- a/content/io/cloudslang/docker/containers/examples/demo_dev_ops.sl
+++ b/content/io/cloudslang/docker/containers/examples/demo_dev_ops.sl
@@ -24,9 +24,6 @@
 #   - email_sender - email sender
 #   - email_recipient - email recipient
 #   - timeout - optional - time in milliseconds to wait for command to complete - Default: 30000000 ms (8.33 h)
-# Results:
-#   - SUCCESS
-#   - FAILURE
 ####################################################
 namespace: io.cloudslang.docker.containers.examples
 

--- a/content/io/cloudslang/docker/containers/get_all_containers.sl
+++ b/content/io/cloudslang/docker/containers/get_all_containers.sl
@@ -10,25 +10,23 @@
 #
 # Inputs:
 #   - all_containers - adds all_container option to docker command. False by default, any input changes it to True
-#   - ps_params - option trigger to add all_containers option to docker command
+#   - ps_params - option trigger to add all_containers option to Docker command
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username - Docker machine username
 #   - password - optional - Docker machine password
 #   - private_key_file - optional - path to private key file
 #   - arguments - optional - arguments to pass to the command
 #   - character_set - optional - character encoding used for input stream encoding from target machine;
 #                              - Valid: 'SJIS', 'EUC-JP', 'UTF-8'
-#                              - Default: 'UTF-8'
-#   - pty - whether to use PTY - Valid: true, false - Default: false
-#   - timeout - time in milliseconds to wait for command to complete - Default: '30000000'
+#   - pty - whether to use PTY - Valid: true, false
+#   - timeout - time in milliseconds to wait for command to complete
 #   - close_session - optional - if 'false' SSH session will be cached for future calls during the life of the flow,
 #                                if 'true' the SSH session used will be closed;
 #                              - Valid: true, false
-#                              - Default: false
 #   - agent_forwarding - optional - the sessionObject that holds the connection if the close session is false
 # Outputs:
-#   - container_list - list containing container ID for all the Docker containers, separated by space
+#   - container_list - list containing container IDs for all the Docker containers, separated by space
 # Results:
 #   - SUCCESS - SSH command succeeded
 #   - FAILURE - SSH command failed

--- a/content/io/cloudslang/docker/containers/get_all_containers.sl
+++ b/content/io/cloudslang/docker/containers/get_all_containers.sl
@@ -43,6 +43,7 @@ flow:
     - all_containers: false
     - ps_params: ${'-a' if bool(all_containers) else ''}
     - command: ${'docker ps -q ' + ps_params}
+        overridable: false
     - host
     - port:
         required: false

--- a/content/io/cloudslang/docker/containers/get_all_containers.sl
+++ b/content/io/cloudslang/docker/containers/get_all_containers.sl
@@ -42,7 +42,8 @@ flow:
   inputs:
     - all_containers: false
     - ps_params: ${'-a' if bool(all_containers) else ''}
-    - command: ${'docker ps -q ' + ps_params}
+    - command:
+        default: ${'docker ps -q ' + ps_params}
         overridable: false
     - host
     - port:

--- a/content/io/cloudslang/docker/containers/get_container_ip.sl
+++ b/content/io/cloudslang/docker/containers/get_container_ip.sl
@@ -27,9 +27,6 @@
 # Outputs:
 #   - container_ip - IP of the specified container
 #   - error_message - error message
-# Results:
-#   - SUCCESS
-#   - FAILURE
 ####################################################
 namespace: io.cloudslang.docker.containers
 

--- a/content/io/cloudslang/docker/containers/get_container_ip.sl
+++ b/content/io/cloudslang/docker/containers/get_container_ip.sl
@@ -9,21 +9,20 @@
 # Gets the IP of the specified Docker container.
 #
 # Inputs:
-#   - containerName - container name
+#   - container_name - container name
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username - Docker machine username
 #   - password - Docker machine password
-#   - private_key_file - optional - absolute path to private key file - Default: none
-#   - arguments - optional - arguments to pass to the command; Default: none
+#   - private_key_file - optional - absolute path to private key file
+#   - arguments - optional - arguments to pass to the command
 #   - character_set - optional - character encoding used for input stream encoding from target machine
-#                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8' - Default: 'UTF-8'
-#   - pty - optional - whether to use PTY - Valid: true, false - Default: false
-#   - timeout - optional - time in milliseconds to wait for command to complete - Default: '90000'
+#                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8'
+#   - pty - optional - whether to use PTY - Valid: true, false
+#   - timeout - optional - time in milliseconds to wait for command to complete
 #   - close_session - optional - if 'false' SSH session will be cached for future calls during the life of the flow,
 #                                if 'true' the SSH session used will be closed;
 #                              - Valid: true, false
-#                              - Default: false
 #   - agent_forwarding - optional - the sessionObject that holds the connection if the close session is false
 # Outputs:
 #   - container_ip - IP of the specified container

--- a/content/io/cloudslang/docker/containers/get_container_ip.sl
+++ b/content/io/cloudslang/docker/containers/get_container_ip.sl
@@ -40,7 +40,8 @@ flow:
   name: get_container_ip
   inputs:
     - container_name
-    - command: ${"docker inspect --format '{{ .NetworkSettings.IPAddress }}' " + container_name}
+    - command:
+        default: ${"docker inspect --format '{{ .NetworkSettings.IPAddress }}' " + container_name}
         overridable: false
     - host
     - port:

--- a/content/io/cloudslang/docker/containers/get_container_ip.sl
+++ b/content/io/cloudslang/docker/containers/get_container_ip.sl
@@ -41,6 +41,7 @@ flow:
   inputs:
     - container_name
     - command: ${"docker inspect --format '{{ .NetworkSettings.IPAddress }}' " + container_name}
+        overridable: false
     - host
     - port:
         required: false

--- a/content/io/cloudslang/docker/containers/get_container_names.sl
+++ b/content/io/cloudslang/docker/containers/get_container_names.sl
@@ -28,9 +28,6 @@
 # Outputs:
 #   - container_names - list of container names separated by space
 #   - raw_output - unparsed return result from the machine
-# Results:
-#   - SUCCESS - successful
-#   - FAILURE - otherwise
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/get_filtered_containers.sl
+++ b/content/io/cloudslang/docker/containers/get_filtered_containers.sl
@@ -14,7 +14,7 @@
 #                    - any input that is different than empty string or false (as boolean type) changes its value to True
 #   - excluded_images - comma separated list of Docker images
 #                     - the containers based on these images will not be included in the result list
-#                     - e.g. swarm:latest,tomcat:7
+#                     - Example: swarm:latest,tomcat:7
 #   - host - Docker machine host
 #   - port - optional - SSH port
 #   - username - Docker machine username
@@ -23,14 +23,14 @@
 #   - character_set - optional - character encoding used for input stream encoding from target machine;
 #                              - Valid: SJIS, EUC-JP, UTF-8
 #   - pty - optional - whether to use PTY - Valid: true, false
-#   - timeout - optional - time in milliseconds to wait for command to complete - Default: 600000 ms (10 min)
+#   - timeout - optional - time in milliseconds to wait for command to complete
 #   - close_session - optional - if false SSH session will be cached for future calls during the life of the flow,
 #                                if true the SSH session used will be closed;
 #                              - Valid: true, false
 #   - agent_forwarding - optional - enables or disables the forwarding of the authentication agent connection
 # Outputs:
 #   - container_names - comma separated list of container names
-#   - container_ids - comma separated list of container names
+#   - container_ids - comma separated list of container IDs
 # Results:
 #   - SUCCESS - successful
 #   - FAILURE - otherwise

--- a/content/io/cloudslang/docker/containers/get_filtered_containers.sl
+++ b/content/io/cloudslang/docker/containers/get_filtered_containers.sl
@@ -31,9 +31,6 @@
 # Outputs:
 #   - container_names - comma separated list of container names
 #   - container_ids - comma separated list of container IDs
-# Results:
-#   - SUCCESS - successful
-#   - FAILURE - otherwise
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/run_container.sl
+++ b/content/io/cloudslang/docker/containers/run_container.sl
@@ -118,4 +118,4 @@ flow:
           - standard_err
   outputs:
     - container_id
-    - standard_err
+    - error_message: ${standard_err}

--- a/content/io/cloudslang/docker/containers/run_container.sl
+++ b/content/io/cloudslang/docker/containers/run_container.sl
@@ -31,9 +31,6 @@
 # Outputs:
 #   - container_id - ID of the container
 #   - standard_err - STDERR of the machine in case of successful request, null otherwise
-# Results:
-#   - SUCCESS - successful
-#   - FAILURE - otherwise
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/run_container.sl
+++ b/content/io/cloudslang/docker/containers/run_container.sl
@@ -9,7 +9,7 @@
 # Pulls and runs a Docker container.
 #
 # Inputs:
-#   - docker_options - optional - options for the docker environment - from the construct: docker [OPTIONS] COMMAND [arg...]
+#   - docker_options - optional - options for the Docker environment - from the construct: docker [OPTIONS] COMMAND [arg...]
 #   - detach - optional - run container in background (detached / daemon mode) - Default: true
 #   - container_name - optional - container name
 #   - container_params - optional - command parameters

--- a/content/io/cloudslang/docker/containers/start_container.sl
+++ b/content/io/cloudslang/docker/containers/start_container.sl
@@ -26,9 +26,6 @@
 # Outputs:
 #   - container_id - ID of the container that was started
 #   - error_message - error message
-# Results:
-#   - SUCCESS
-#   - FAILURE
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/start_container.sl
+++ b/content/io/cloudslang/docker/containers/start_container.sl
@@ -12,20 +12,19 @@
 #   - container_id - ID of the container to be started
 #   - container_params - optional - command parameters - Default: none
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username - Docker machine username
 #   - password - optional - Docker machine password
-#   - private_key_file - optional - absolute path to private key file - Default: none
-#   - arguments - optional - arguments to pass to command - Default: none
+#   - private_key_file - optional - absolute path to private key file
+#   - arguments - optional - arguments to pass to command
 #   - character_set - optional - character encoding used for input stream encoding from target machine
 #                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8'
-#                             - Default: 'UTF-8'
-#   - pty - optional - whether to use PTY - Valid: true, false - Default: false
-#   - timeout - optional - time in milliseconds to wait for the command to complete; Default: 90000 ms
+#   - pty - optional - whether to use PTY - Valid: true, false
+#   - timeout - optional - time in milliseconds to wait for the command to complete
 #   - close_session - optional - if 'false' SSH session will be cached for future calls during the life of the flow,
-#                               if 'true' the SSH session used will be closed; Valid: true, false - Default: false
+#                               if 'true' the SSH session used will be closed; Valid: true, false
 # Outputs:
-#   - container_id - ID of the container that was deleted
+#   - container_id - ID of the container that was started
 #   - error_message - error message
 # Results:
 #   - SUCCESS

--- a/content/io/cloudslang/docker/containers/start_container.sl
+++ b/content/io/cloudslang/docker/containers/start_container.sl
@@ -53,6 +53,7 @@ flow:
     - arguments:
         required: false
     - container_params_cmd: ${container_params + ' ' if bool(container_params) else ''}
+        overridable: false
     - command:
         default: ${'docker start ' + container_params_cmd + ' ' + container_id}
         overridable: false

--- a/content/io/cloudslang/docker/containers/start_container.sl
+++ b/content/io/cloudslang/docker/containers/start_container.sl
@@ -52,7 +52,8 @@ flow:
         required: false
     - arguments:
         required: false
-    - container_params_cmd: ${container_params + ' ' if bool(container_params) else ''}
+    - container_params_cmd:
+        default: ${container_params + ' ' if bool(container_params) else ''}
         overridable: false
     - command:
         default: ${'docker start ' + container_params_cmd + ' ' + container_id}

--- a/content/io/cloudslang/docker/containers/start_linked_container.sl
+++ b/content/io/cloudslang/docker/containers/start_linked_container.sl
@@ -30,9 +30,6 @@
 # Outputs:
 #   - container_id - ID of the container that was started
 #   - error_message - error message
-# Results:
-#   - SUCCESS
-#   - FAILURE
 ####################################################
 
 namespace: io.cloudslang.docker.containers

--- a/content/io/cloudslang/docker/containers/start_linked_container.sl
+++ b/content/io/cloudslang/docker/containers/start_linked_container.sl
@@ -6,31 +6,29 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 ####################################################
-# Start a linked container.
+# Starts a linked container.
 #
 # Inputs:
 #   - image_name - image name
 #   - container_name - linked container name
 #   - link_params - link parameters
-#   - cmd_params - command Parameters
+#   - cmd_params - command parameters
 #   - container_cmd - optional - command to be executed in the container
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username: Docker machine username
 #   - password - optional - Docker machine password
 #   - private_key_file - optional - path to private key file
-#   - arguments - optional - arguments to pass to command - Default: none
+#   - arguments - optional - arguments to pass to command
 #   - character_set - optional - character encoding used for input stream encoding from target machine
 #                             - Valid: SJIS, EUC-JP, UTF-8
-#                             - Default: UTF-8
-#   - pty - optional - whether to use PTY - Valid: true, false - Default: false
-#   - timeout - optional - time in milliseconds to wait for command to complete - Default: '90000'
+#   - pty - optional - whether to use PTY - Valid: true, false
+#   - timeout - optional - time in milliseconds to wait for command to complete
 #   - close_session - optional - if false SSH session will be cached for future calls during the life of the flow,
 #                               if true the SSH session used will be closed;
 #                             - Valid: true, false
-#                             - Default: false
 # Outputs:
-#   - container_id - ID of the container that was started.
+#   - container_id - ID of the container that was started
 #   - error_message - error message
 # Results:
 #   - SUCCESS

--- a/content/io/cloudslang/docker/containers/stop_container.sl
+++ b/content/io/cloudslang/docker/containers/stop_container.sl
@@ -6,29 +6,28 @@
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 ####################################################
-# Stop the specified Docker container.
+# Stops the specified Docker container.
 #
 # Inputs:
 #   - container_id - ID of the container to be deleted
 #   - docker_options - optional - options for the docker environment - from the construct: docker [OPTIONS] COMMAND [arg...]
-#   - cmd_params - optional - command parameters - Default: none
+#   - cmd_params - optional - command parameters
 #   - host - Docker machine host
-#   - port - optional - SSH port - Default: '22'
+#   - port - optional - SSH port
 #   - username - Docker machine username
 #   - password - optional - Docker machine password
 #   - private_key_file - optional - absolute path to private key file
-#   - arguments - optional - arguments to pass to command - Default: none
+#   - arguments - optional - arguments to pass to command
 #   - character_set - optional - character encoding used for input stream encoding from target machine
 #                             - Valid: 'SJIS', 'EUC-JP', 'UTF-8'
-#                             - Default: 'UTF-8'
-#   - pty - optional - whether to use PTY - Valid: true, false - Default: false
-#   - timeout - optional - time in milliseconds to wait for command to complete - Default: '90000'
+#   - pty - optional - whether to use PTY - Valid: true, false
+#   - timeout - optional - time in milliseconds to wait for command to complete
 #   - close_session - optional - if false SSH session will be cached for future calls during the life of the flow,
 #                                if true the SSH session used will be closed;
 #                              - Valid: true, false
-#                              - Default: false
+#   - agent_forwarding - optional - the sessionObject that holds the connection if the close session is false
 # Outputs:
-#   - result - ID of the container that was deleted
+#   - result - ID of the container that was stopped
 # Results:
 #   - SUCCESS
 #   - FAILURE
@@ -71,7 +70,7 @@ flow:
         required: false
     - close_session:
         required: false
-    - agentForwarding:
+    - agent_forwarding:
         required: false
 
   workflow:
@@ -89,7 +88,7 @@ flow:
             - pty
             - timeout
             - close_session
-            - agentForwarding
+            - agent_forwarding
         publish:
           - result: ${return_result.replace("\n","")}
           - standard_out

--- a/content/io/cloudslang/docker/containers/stop_container.sl
+++ b/content/io/cloudslang/docker/containers/stop_container.sl
@@ -49,6 +49,7 @@ flow:
     - cmd_params:
         required: false
     - params: ${cmd_params + ' ' if bool(cmd_params) else ''}
+        overridable: false
     - host
     - port:
         required: false

--- a/content/io/cloudslang/docker/containers/stop_container.sl
+++ b/content/io/cloudslang/docker/containers/stop_container.sl
@@ -48,7 +48,8 @@ flow:
         overridable: false
     - cmd_params:
         required: false
-    - params: ${cmd_params + ' ' if bool(cmd_params) else ''}
+    - params:
+        default: ${cmd_params + ' ' if bool(cmd_params) else ''}
         overridable: false
     - host
     - port:

--- a/test/io/cloudslang/docker/containers/test_get_all_containers.sl
+++ b/test/io/cloudslang/docker/containers/test_get_all_containers.sl
@@ -72,7 +72,7 @@ flow:
             - container_name: 'first_test_container'
             - image_name: ${first_image_name}
         publish:
-          - standard_err
+          - error_message
         navigate:
           SUCCESS: run_second_container
           FAILURE: FAIL_RUN_IMAGE
@@ -87,7 +87,7 @@ flow:
             - container_name: 'second_test_container'
             - image_name: ${second_image_name}
         publish:
-          - standard_err
+          - error_message
         navigate:
           SUCCESS: get_all_containers
           FAILURE: FAIL_RUN_IMAGE

--- a/test/io/cloudslang/docker/containers/test_get_filtered_containers.sl
+++ b/test/io/cloudslang/docker/containers/test_get_filtered_containers.sl
@@ -92,7 +92,7 @@ flow:
             - timeout
        publish:
           - expected_container_ids: ${container_id}
-          - standard_err
+          - error_message
        navigate:
          SUCCESS: execute_get_filtered_containers
          FAILURE: print_error
@@ -100,7 +100,7 @@ flow:
     - print_error:
         do:
           print.print_text:
-            - text: standard_err
+            - text: error_message
         navigate:
           SUCCESS: RUN_CONTAINER_PYTHON_PROBLEM
 


### PR DESCRIPTION
Questions:

+ params input: in both `delete_container` and `stop_container` the `params` input is not documented. Is it supposed to be `overridable: false`? If not, please provide a description.
+ standard_err output: in both `delete_container` and `run_container` have and output named `standard_output` whereas most other flows have an output named `error_message`. Should we switch `standard_err` to `error_message`.
+ command input: in both `get_all_containers` and `get_container_ip` the `command` input is not documented. Is it supposed to be `overridable: false`? If not, please provide a description.
+ container_params_cmd: in `start_container` same issue as above