### PR TITLE
Fix for ALM#30535: Passed command input from ssh_flow to its validate…

### DIFF
--- a/content/io/cloudslang/base/os/linux/validate_linux_machine_ssh_access.sl
+++ b/content/io/cloudslang/base/os/linux/validate_linux_machine_ssh_access.sl
@@ -53,7 +53,6 @@ operation:
         private: true
     - command:
         default: ':'
-        private: true
     - arguments:
         required: false
     - character_set:

--- a/content/io/cloudslang/base/ssh/ssh_command.sl
+++ b/content/io/cloudslang/base/ssh/ssh_command.sl
@@ -12,7 +12,7 @@
 #! @input port: optional - port number for running the command - Default: '22'
 #! @input command: command to execute
 #! @input pty: optional - whether to use PTY - Valid: true, false - Default: false
-               When pty is true, the desired command must be appended with an exit command in order to close the channel, e.g. "echo something\n exit\n", otherwise the operation will time out
+#!             When pty is true, the desired command must be appended with an exit command in order to close the channel, e.g. "echo something\n exit\n", otherwise the operation will time out
 #! @input username: username to connect as
 #! @input password: optional - password of user
 #! @input arguments: optional - arguments to pass to the command

--- a/content/io/cloudslang/base/ssh/ssh_command.sl
+++ b/content/io/cloudslang/base/ssh/ssh_command.sl
@@ -12,6 +12,7 @@
 #! @input port: optional - port number for running the command - Default: '22'
 #! @input command: command to execute
 #! @input pty: optional - whether to use PTY - Valid: true, false - Default: false
+               When pty is true, the desired command must be appended with an exit command in order to close the channel, e.g. "echo something\n exit\n", otherwise the operation will time out
 #! @input username: username to connect as
 #! @input password: optional - password of user
 #! @input arguments: optional - arguments to pass to the command

--- a/content/io/cloudslang/base/ssh/ssh_flow.sl
+++ b/content/io/cloudslang/base/ssh/ssh_flow.sl
@@ -12,6 +12,7 @@
 #! @input port: optional - port number for running the command - Default: '22'
 #! @input command: command to execute
 #! @input pty: optional - whether to use PTY - Valid: true, false - Default: false
+#!             When pty is true, the desired command must be appended with an exit command in order to close the channel, e.g. "echo something\n exit\n", otherwise the operation will time out
 #! @input username: username to connect as
 #! @input password: optional - password of user
 #! @input arguments: optional - arguments to pass to the command
@@ -99,6 +100,8 @@ flow:
               - timeout
               - close_session
               - agent_forwarding
+              - command
+
           publish:
             - return_result
             - return_code

--- a/test/io/cloudslang/base/ssh/ssh_flow.inputs.yaml
+++ b/test/io/cloudslang/base/ssh/ssh_flow.inputs.yaml
@@ -63,3 +63,16 @@ testSSHexitStatusCommandNotFound:
     - command_return_code: 127
   testSuites: [docker,docker-misc]
   result: SUCCESS
+
+testSSHWorksWhenPTYtrue:
+  inputs:
+    - host: localhost
+    - port: "49153"
+    - command: "echo testing\nexit\n"
+    - pty: "true"
+    - username: root
+    - password: screencast
+  description: Tests ssh actually works when pty = true by closing the channel with an appended exit command
+  testFlowPath: io.cloudslang.base.ssh.ssh_flow
+  testSuites: [docker,docker-misc]
+  result: SUCCESS

--- a/test/io/cloudslang/base/ssh/ssh_flow.inputs.yaml
+++ b/test/io/cloudslang/base/ssh/ssh_flow.inputs.yaml
@@ -62,7 +62,6 @@ testSSHexitStatusCommandNotFound:
   outputs:
     - command_return_code: 127
   testSuites: [docker,docker-misc]
-  result: SUCCESS
 
 testSSHWorksWhenPTYtrue:
   inputs:


### PR DESCRIPTION
…_linux_machine_ssh_access step; Removed 'private: true' setting for command input in validate_linux_machine_ssh_access.sl; enhanced description for pty input in ssh_command.sl and ssh_flow.sl

Signed off by: Alexandru Duma <alexandru.duma@hpe.com>