### PR TITLE
fix bug for bad output folder

### DIFF
--- a/content/io/cloudslang/base/files/unzip_archive.sl
+++ b/content/io/cloudslang/base/files/unzip_archive.sl
@@ -35,6 +35,7 @@ operation:
           message = 'unzipping done successfully'
           result = True
         except Exception as e:
+          fh.close()
           message = e
           result = False
 

--- a/content/io/cloudslang/base/files/unzip_archive.sl
+++ b/content/io/cloudslang/base/files/unzip_archive.sl
@@ -26,6 +26,7 @@ operation:
   python_action:
     script: |
         import zipfile
+        fh = None
         try:
           fh = open(archive_path, 'rb')
           z = zipfile.ZipFile(fh)
@@ -35,7 +36,8 @@ operation:
           message = 'unzipping done successfully'
           result = True
         except Exception as e:
-          fh.close()
+          if fh != None:
+            fh.close()
           message = e
           result = False
 


### PR DESCRIPTION
When the input 'output_folder' contains a bad directory name the zip archive remains open.
I fixed that bug.