### PR TITLE
added test on strings for input bool_value

### DIFF
--- a/content/io/cloudslang/base/utils/is_true.sl
+++ b/content/io/cloudslang/base/utils/is_true.sl
@@ -21,5 +21,5 @@ decision:
   inputs:
     - bool_value
   results:
-    - SUCCESS: ${ bool_value == True or bool_value == "True" }
+    - SUCCESS: ${ bool_value in [True, true, 'True', 'true'] }
     - FAILURE

--- a/content/io/cloudslang/base/utils/is_true.sl
+++ b/content/io/cloudslang/base/utils/is_true.sl
@@ -21,5 +21,5 @@ decision:
   inputs:
     - bool_value
   results:
-    - SUCCESS: ${ bool_value == True }
+    - SUCCESS: ${ bool_value == True or bool_value == "True" }
     - FAILURE


### PR DESCRIPTION
The operation doesn't work on central because in central the input is given as String. I added also a comparison for strings in order to work both on central and CloudSlang-cli.