### PR TITLE
rename [base] json add_entry_in_object.sl and fix it

### DIFF
--- a/content/io/cloudslang/base/json/add_json_property_to_object.sl
+++ b/content/io/cloudslang/base/json/add_json_property_to_object.sl
@@ -23,7 +23,7 @@
 namespace: io.cloudslang.base.json
 
 operation:
-  name: add_entry_in_object
+  name: add_json_property_to_object
   inputs:
     - json_object
     - key

--- a/content/io/cloudslang/base/json/add_json_property_to_object.sl
+++ b/content/io/cloudslang/base/json/add_json_property_to_object.sl
@@ -33,8 +33,8 @@ operation:
     script: |
       try:
         import json
-        from collections import OrderedDict
-        decoded = json.loads(json_object,object_pairs_hook=OrderedDict)
+
+        decoded = json.loads(json_object)
         decoded_value = json.loads(value)
         decoded[key] = decoded_value
 

--- a/content/io/cloudslang/base/json/add_json_property_to_object.sl
+++ b/content/io/cloudslang/base/json/add_json_property_to_object.sl
@@ -33,8 +33,8 @@ operation:
     script: |
       try:
         import json
-
-        decoded = json.loads(json_object)
+        from collections import OrderedDict
+        decoded = json.loads(json_object,object_pairs_hook=OrderedDict)
         decoded_value = json.loads(value)
         decoded[key] = decoded_value
 

--- a/content/io/cloudslang/cloud/openstack/servers/create_server_flow.sl
+++ b/content/io/cloudslang/cloud/openstack/servers/create_server_flow.sl
@@ -376,7 +376,7 @@ flow:
 
     - add_metadata:
         do:
-          json.add_entry_in_object:
+          json.add_json_property_to_object:
             - json_object: ${body_json}
             - key: 'metadata'
             - value: ${metadata}

--- a/test/io/cloudslang/base/json/add_json_property_to_object.inputs.yaml
+++ b/test/io/cloudslang/base/json/add_json_property_to_object.inputs.yaml
@@ -14,8 +14,8 @@ testAddPropertySuccess:
     - json_object: "{}"
     - key: "test"
     - value: "[1,2,3]"
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -29,8 +29,8 @@ testAddValidProperty:
     - json_object: '{"server": {"security_groups": [{"name": "default"}], "networks": []}}'
     - key: 'block_device_mapping_v2'
     - value: '{"source_type": "image", "uuid": "b67f9da0-4a89-4588-b0f5-bf4d19401743", "boot_index": "0", "delete_on_termination": true}'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -42,8 +42,8 @@ testAddPropertySuccess1:
     - json_object: "{}"
     - key: "test"
     - value: '{"a": "b"}'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -55,8 +55,8 @@ testAddPropertySuccess2:
     - json_object: "{}"
     - key: "test"
     - value: '1'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -71,8 +71,8 @@ testAddPropertySuccess3:
     - json_object: '{"one":1, "two":2}'
     - key: "three"
     - value: '3'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes withy success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes withy success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -86,8 +86,8 @@ testAddPropertySuccess4:
     - json_object: '{"one":{"a":"a","B":"B"}}'
     - key: "two"
     - value: '{"b":"b","A":"A"}'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -97,8 +97,8 @@ testAddPropertyFailureInvalidValue:
     - json_object: '{"one":{"a":"a","B":"B"}}'
     - key: "two"
     - value: '{"b":"b","A":"A"}}'
-  description: "Tests that add_entry_in_object.inputs.yaml operation goes to failure when an invalid value is given."
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.inputs.yaml operation goes to failure when an invalid value is given."
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "ValueError('Extra data: line 1 column 18 - line 1 column 19 (char 17 - 18)',)"
     - return_code: "-1"
@@ -110,8 +110,8 @@ testAddPropertyFailureInvalidJsonObject:
     - json_object: '{"one":{"a":"a","B":"B"}a'
     - key: "two"
     - value: '{"b":"b","A":"A"}'
-  description: "Tests that add_entry_in_object.inputs.yaml operation goes to failure when an invalid json_object is given."
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.inputs.yaml operation goes to failure when an invalid json_object is given."
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "ValueError('Expecting , delimiter: line 1 column 25 (char 24)',)"
     - return_code: "-1"
@@ -123,8 +123,8 @@ testAddPropertyInvalidJsonObject:
     - json_object: '{"key":value}'
     - key: "KEY"
     - value: '{"VALUE1":"VALUE2"}'
-  description: "Tests that add_entry_in_object.inputs.yaml operation goes to failure when an invalid json_object is given."
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.inputs.yaml operation goes to failure when an invalid json_object is given."
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   outputs:
     - return_result: "ValueError('No JSON object could be decoded',)"
     - return_code: "-1"
@@ -196,8 +196,8 @@ testAddPropertyLargeJsonDocument:
                                                                                                  }
                                                                                   ]
                                                                    }'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.add_json_property_to_object
   outputs:
     - return_result: "Added successfully."
   result: SUCCESS
@@ -215,8 +215,8 @@ testAddProperty:
                                ]}'
     - key: "employees2"
     - value: '{"firstName":"Jane","lastName":"Doe"}'
-  description: "Tests that add_entry_to_object.sl correctly adds properties to json object and finishes with success"
-  testFlowPath: io.cloudslang.base.json.test_add_entry_in_object
+  description: "Tests that add_json_property_to_object.sl correctly adds properties to json object and finishes with success"
+  testFlowPath: io.cloudslang.base.json.test_add_json_property_to_object
   result: SUCCESS
   outputs:
     - return_result: "Added successfully."

--- a/test/io/cloudslang/base/json/test_add_json_property_to_object.sl
+++ b/test/io/cloudslang/base/json/test_add_json_property_to_object.sl
@@ -5,7 +5,7 @@ imports:
   strings: io.cloudslang.base.strings
 
 flow:
-  name: test_add_entry_in_object
+  name: test_add_json_property_to_object
 
   inputs:
     - json_object:
@@ -26,7 +26,7 @@ flow:
   workflow:
     - add_JSON_property_in_object:
         do:
-          json.add_entry_in_object:
+          json.add_json_property_to_object:
             - json_object
             - key
             - value


### PR DESCRIPTION
Rename [base] json add_entry_in_object.sl to add_json_property_to_object.sl and fix it that json output bring the keys in the same order as in inputs (This is expected behavior for this operation)
Signed-off-by: Liviu Graur liviu.graur@hpe.com