### PR TITLE
Modification of the cmd flow, in order to give None to the python script and to overwrite the var cwd only if not provided by the user

### DIFF
--- a/content/io/cloudslang/base/cmd/run_command.sl
+++ b/content/io/cloudslang/base/cmd/run_command.sl
@@ -34,7 +34,7 @@ operation:
     - command
     - cwd:
         required: false
-        default: None
+        default: null
 
   python_action:
     script: |
@@ -43,7 +43,7 @@ operation:
       return_code = 0
       return_result = ''
       error_message = ''
-      cwd = os.getcwd() if cwd is not None else cwd
+      cwd = os.getcwd() if cwd is None else cwd
       try:
         res = subprocess.Popen(command,cwd=cwd,stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True);
         output,error = res.communicate()


### PR DESCRIPTION
Closes: #933 

The default value is now "null" in order to get None in the python script.
The condition to overwrite cwd is changed in order to do a os.getcwd() if cwd is null.