### PR TITLE
Update builder v 1 0 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - docker info
   - docker version
   - df -kh
-  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.4/cslang-builder.zip
+  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.5/cslang-builder.zip
   - unzip -q cslang-builder.zip
   - chmod +x cslang-builder/bin/cslang-builder
   - ./cslang-builder/bin/cslang-builder -ts ${SUITE},\!default -cov -des -cs

--- a/circle.yml
+++ b/circle.yml
@@ -79,7 +79,7 @@ dependencies:
         fi
       : parallel: true
     - ? > ### every machine
-        wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.4/cslang-builder.zip
+        wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.5/cslang-builder.zip
         && unzip cslang-builder.zip
         && chmod +x cslang-builder/bin/cslang-builder
         && mkdir cslang-builder/lib/Lib


### PR DESCRIPTION
This [Pull Request](https://help.github.com/articles/about-pull-requests/) is intended to solve the propagation of a new [CloudSlang](http://cloudslang.io/#/) builder version. CloudSlang is an open source tool for orchestrating cutting edge technologies. It can orchestrate anything you can imagine in an agentless manner. You can use or customize ready-made YAML based workflows. They are powerful, shareable and human readable. Modernize your IT with CloudSlang.

The CloudSlang Build Tool checks the syntactic validity of CloudSlang files, their adherence to many of the best practices and runs their associated tests.Running the CloudSlang Build Tool performs the following steps, each of which is written to the console:

- Displays the active project, content and test paths.
- Displays a list of the active test suites.
- Compiles all CloudSlang files found in the content directory and all of its subfolders.
- If there is a compilation error, it is displayed and the build terminates.
- Compiles all CloudSlang test flows found in the test directory and all of its subfolders.
- Parses all test cases files found in the test directory and all of its subfolders.
- Runs all test cases found in the test case files that have no test suite or have a test suite that is active.
- Displays the test cases that were skipped.
- Reports the build’s status.
- If the build fails, a list of failed test cases are displayed.


You can find more information about the builder too [here](https://github.com/CloudSlang/cloud-slang/tree/master/cloudslang-content-verifier) and [here](http://cloudslang-docs.readthedocs.io/en/v1.0/cloudslang_build_tool.html#download-the-build-tool).

Previous version: `1.0.4`.
Upgrade version: `1.0.5`.
Abut versioning - consult [this page](http://semver.org/).

Changes:
- fixes:
  - https://github.com/CloudSlang/cloud-slang/pull/983 - Accept invalid chars for description item names

All CloudSlang flows and operations should begin with a documentation block that describes the flow or operation, and lists the inputs, outputs and results.A flow or operation’s documentation may be viewed from the CLI using the inspect command.

- Documentation blocks begin with a line containing #!! and nothing else.-
- Documentation blocks end with a line containing #!!# and nothing else.
- Each line of the documentation begins with #!.
- Lines in the documentation block that do not begin with #! will not be considered as part of the documentation and will not display when the file is inspected.
- The @description tag is the only mandatory tag.
- The other possible tags are:
```
@prerequisites
@input <input_name>
@output <output_name>
@result <result_name>
```

The new version should not affect the already existing content in any form. 

Signed-off-by: Bonczidai Levente <levente.bonczidai@hpe.com>