### PR TITLE
Exposed http client inputs

### DIFF
--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -271,7 +271,7 @@ operation:
     - keep_alive:
         required: false
     - keepAlive:
-        default: ${get("keep_alive", "true")}
+        default: ${get("keep_alive", "false")}
         private: true
     - connections_max_per_root:
         required: false

--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -73,10 +73,10 @@
 #!                     Default: 'true'
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
 #!                    Default: 'true'
-#! @input connections_max_per_root: Optional - Maximum limit of connections on a per route basis.
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.
-#!                               Default: '2'
+#!                               Default: '20'
 #! @input headers: Optional - List containing the headers to use for the request separated by new line (CRLF);
 #!                 header name - value pair will be separated by ":".
 #!                 Format: According to HTTP standard for headers (RFC 2616)
@@ -273,10 +273,10 @@ operation:
     - keepAlive:
         default: ${get("keep_alive", "false")}
         private: true
-    - connections_max_per_root:
+    - connections_max_per_route:
         required: false
-    - connectionsMaxPerRoot:
-        default: ${get("connections_max_per_root", "2")}
+    - connectionsMaxPerRoute:
+        default: ${get("connections_max_per_route", "2")}
         private: true
     - connections_max_total:
         required: false

--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -72,7 +72,7 @@
 #! @input use_cookies: Optional - Specifies whether to enable cookie tracking or not.
 #!                     Default: 'true'
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -396,7 +396,7 @@ operation:
         default: ${ str(list(range(200, 300))) }
 
   java_action:
-    gav: 'io.cloudslang.content:cs-http-client:0.1.79'
+    gav: 'io.cloudslang.content:cs-http-client:0.1.80'
     class_name: io.cloudslang.content.httpclient.actions.HttpClientAction
     method_name: execute
 

--- a/content/io/cloudslang/base/http/http_client_delete.sl
+++ b/content/io/cloudslang/base/http/http_client_delete.sl
@@ -66,6 +66,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input request_character_set: Optional - character encoding to be used for the HTTP request body; should not
 #!                               be provided for method=GET, HEAD, TRACE - Default: 'ISO-8859-1'
 #! @input headers: Optional - list containing the headers to use for the request separated by new line (CRLF).
@@ -152,10 +158,13 @@ flow:
         default: '0'
         required: false
     - keep_alive:
+        default: 'false'
         required: false
-    - connections_max_per_root:
+    - connections_max_per_route:
+        default: '2'
         required: false
     - connections_max_total:
+        default: '20'
         required: false
     - request_character_set:
         required: false
@@ -196,7 +205,7 @@ flow:
             - connect_timeout
             - socket_timeout
             - keep_alive
-            - connections_max_per_root
+            - connections_max_per_route
             - connections_max_total
             - request_character_set
             - headers

--- a/content/io/cloudslang/base/http/http_client_delete.sl
+++ b/content/io/cloudslang/base/http/http_client_delete.sl
@@ -151,6 +151,12 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        required: false
+    - connections_max_per_root:
+        required: false
+    - connections_max_total:
+        required: false
     - request_character_set:
         required: false
     - headers:
@@ -189,6 +195,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_root
+            - connections_max_total
             - request_character_set
             - headers
             - query_params

--- a/content/io/cloudslang/base/http/http_client_delete.sl
+++ b/content/io/cloudslang/base/http/http_client_delete.sl
@@ -67,7 +67,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_get.sl
+++ b/content/io/cloudslang/base/http/http_client_get.sl
@@ -67,7 +67,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_get.sl
+++ b/content/io/cloudslang/base/http/http_client_get.sl
@@ -66,6 +66,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input request_character_set: Optional - Character encoding to be used for the HTTP request body; should not
 #!                               be provided for method=GET, HEAD, TRACE
 #!                               Default: 'ISO-8859-1'
@@ -151,6 +157,15 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        default: 'false'
+        required: false
+    - connections_max_per_route:
+        default: '2'
+        required: false
+    - connections_max_total:
+        default: '20'
+        required: false
     - headers:
         required: false
     - query_params:
@@ -187,6 +202,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_route
+            - connections_max_total
             - headers
             - query_params
             - content_type

--- a/content/io/cloudslang/base/http/http_client_patch.sl
+++ b/content/io/cloudslang/base/http/http_client_patch.sl
@@ -67,7 +67,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_patch.sl
+++ b/content/io/cloudslang/base/http/http_client_patch.sl
@@ -66,6 +66,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input request_character_set: Optional - Character encoding to be used for the HTTP request body; should not
 #!                               be provided for method=GET, HEAD, TRACE.
 #!                               Default: 'ISO-8859-1'
@@ -152,6 +158,15 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        default: 'false'
+        required: false
+    - connections_max_per_route:
+        default: '2'
+        required: false
+    - connections_max_total:
+        default: '20'
+        required: false
     - request_character_set:
         required: false
     - headers:
@@ -192,6 +207,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_route
+            - connections_max_total
             - request_character_set
             - headers
             - query_params

--- a/content/io/cloudslang/base/http/http_client_post.sl
+++ b/content/io/cloudslang/base/http/http_client_post.sl
@@ -69,6 +69,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_root: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input request_character_set: Optional - Character encoding to be used for the HTTP request body; should not
 #!                               be provided for method=GET, HEAD, TRACE.
 #!                               Default: 'ISO-8859-1'
@@ -157,6 +163,15 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        default: 'false'
+        required: false
+    - connections_max_per_route:
+        default: '2'
+        required: false
+    - connections_max_total:
+        default: '20'
+        required: false
     - headers:
         required: false
     - query_params:
@@ -195,6 +210,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_route
+            - connections_max_total
             - request_character_set
             - headers
             - query_params

--- a/content/io/cloudslang/base/http/http_client_post.sl
+++ b/content/io/cloudslang/base/http/http_client_post.sl
@@ -70,7 +70,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_root: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_put.sl
+++ b/content/io/cloudslang/base/http/http_client_put.sl
@@ -67,7 +67,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_put.sl
+++ b/content/io/cloudslang/base/http/http_client_put.sl
@@ -66,6 +66,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input request_character_set: Optional - Character encoding to be used for the HTTP request body; should not
 #!                               be provided for method=GET, HEAD, TRACE.
 #!                               Default: 'ISO-8859-1'
@@ -153,6 +159,15 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        default: 'false'
+        required: false
+    - connections_max_per_route:
+        default: '2'
+        required: false
+    - connections_max_total:
+        default: '20'
+        required: false
     - headers:
         required: false
     - query_params:
@@ -195,6 +210,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_route
+            - connections_max_total
             - request_character_set
             - headers
             - query_params

--- a/content/io/cloudslang/base/http/http_client_trace.sl
+++ b/content/io/cloudslang/base/http/http_client_trace.sl
@@ -68,7 +68,7 @@
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
 #! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
-#!                    Default: 'true'
+#!                    Default: 'false'
 #! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
 #!                                  Default: '2'
 #! @input connections_max_total: Optional - Maximum limit of connections in total.

--- a/content/io/cloudslang/base/http/http_client_trace.sl
+++ b/content/io/cloudslang/base/http/http_client_trace.sl
@@ -67,6 +67,12 @@
 #!                         Default: '0' (infinite)
 #! @input socket_timeout: Optional - Time in seconds to wait for data to be retrieved.
 #!                        Default: '0' (infinite)
+#! @input keep_alive: Optional - Specifies whether to create a shared connection that will be used in subsequent calls.
+#!                    Default: 'true'
+#! @input connections_max_per_route: Optional - Maximum limit of connections on a per route basis.
+#!                                  Default: '2'
+#! @input connections_max_total: Optional - Maximum limit of connections in total.
+#!                               Default: '20'
 #! @input headers: Optional - List containing the headers to use for the request separated by new line (CRLF).
 #!                 Header name - value pair will be separated by ":"
 #!                 Format: According to HTTP standard for headers (RFC 2616)
@@ -155,6 +161,15 @@ flow:
     - socket_timeout:
         default: '0'
         required: false
+    - keep_alive:
+        default: 'false'
+        required: false
+    - connections_max_per_route:
+        default: '2'
+        required: false
+    - connections_max_total:
+        default: '20'
+        required: false
     - headers:
         default: ''
         required: false
@@ -193,6 +208,9 @@ flow:
             - keystore_password
             - connect_timeout
             - socket_timeout
+            - keep_alive
+            - connections_max_per_route
+            - connections_max_total
             - headers
             - query_params
             - content_type


### PR DESCRIPTION
exposed keep_alive, max_connections_per_route and max_connection_total inputs
changed default value to false for keep_alive
updated gav version to 0.1.80