### PR TITLE
Changed default encoding type from the default python one to the utf-8

### DIFF
--- a/content/io/cloudslang/base/filesystem/write_to_file.sl
+++ b/content/io/cloudslang/base/filesystem/write_to_file.sl
@@ -44,7 +44,7 @@ operation:
     - file_path
     - text
     - encode_type:
-        default: 'utf-8'
+        default: 'utf_8'
         required: false
 
   python_action:

--- a/content/io/cloudslang/base/filesystem/write_to_file.sl
+++ b/content/io/cloudslang/base/filesystem/write_to_file.sl
@@ -44,6 +44,7 @@ operation:
     - file_path
     - text
     - encode_type:
+        default: 'utf-8'
         required: false
 
   python_action:


### PR DESCRIPTION
This change was made in order to fix some bug for special characters and inconsistency with AFL. The default encoding was changed to utf_8 since that is the default for AFL

Signed-off-by: ABenta <benta.andinomm@gmail.com>