### PR TITLE
AWS security group limit changed from 5 to 16

### DIFF
--- a/content/io/cloudslang/amazon/aws/ec2/securitygroups/allow_access_to_security_group.sl
+++ b/content/io/cloudslang/amazon/aws/ec2/securitygroups/allow_access_to_security_group.sl
@@ -13,8 +13,8 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This flow attaches up to a maximum of five security groups to the instance. An error will be generated
-#!               if the number of security groups is greater than 5, if the security group to be added is already
+#! @description: This flow attaches up to a maximum of 16 security groups to the instance. An error will be generated
+#!               if the number of security groups is greater than 16, if the security group to be added is already
 #!               present,or if the security group ID is invalid.
 #!
 #! @input endpoint: The AWS endpoint as described here: https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/content/io/cloudslang/amazon/aws/ec2/utils/attach_security_group_condition_check.sl
+++ b/content/io/cloudslang/amazon/aws/ec2/utils/attach_security_group_condition_check.sl
@@ -13,7 +13,7 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This operation returns success, If the number of security groups is less than or equal to 5 and
+#! @description: This operation returns success, If the number of security groups is less than or equal to 16 and
 #!               the security group to be added does not already exist.
 #!
 #! @input security_group_ids_new: The security group Ids which are to be attached to the instance.
@@ -22,7 +22,7 @@
 #! @output return_result: If successful, returns a message
 #! @output error_message: If there is an exception or error message.
 #!
-#! @result SUCCESS: If the number of security groups is less than or equal to 5 and
+#! @result SUCCESS: If the number of security groups is less than or equal to 16 and
 #!                  the security group to be added does not already exist, success is returned.
 #! @result FAILURE: Something went wrong.
 #!!#
@@ -42,8 +42,8 @@ operation:
           error_message = ""
           return_result = ""
           if(security_group_ids_new):
-              if((len(security_group_ids_new.split(',')))+(len(security_group_ids_old.split(',')))>5):
-                  error_message = "Security Group limit exceeded.Number of security groups for an instance should be less than or equal to 5."
+              if((len(security_group_ids_new.split(',')))+(len(security_group_ids_old.split(',')))>16):
+                  error_message = "Security Group limit exceeded.Number of security groups for an instance should be less than or equal to 16."
               else:
                   common_security_group=0
                   security_group_ids_new=security_group_ids_new.split(',')


### PR DESCRIPTION
Changed the attach security group and the python operation to accept a maximum of 16 