### PR TITLE
Updated deploy_cassandra_application flow

### DIFF
--- a/content/io/cloudslang/kubernetes/samples/deploy_cassandra_application.sl
+++ b/content/io/cloudslang/kubernetes/samples/deploy_cassandra_application.sl
@@ -1,4 +1,4 @@
-#   Copyright 2023 Open Text
+#   Copyright 2025 Open Text
 #   This program and the accompanying materials
 #   are made available under the terms of the Apache License v2.0 which accompany this distribution.
 #
@@ -89,10 +89,10 @@ flow:
         required: false
         sensitive: true
     - trust_all_roots:
-        default: 'true'
+        default: 'false'
         required: false
     - x_509_hostname_verifier:
-        default: allow_all
+        default: strict
         required: false
     - trust_keystore:
         required: false

--- a/content/io/cloudslang/kubernetes/samples/deploy_cassandra_application.sl
+++ b/content/io/cloudslang/kubernetes/samples/deploy_cassandra_application.sl
@@ -1,4 +1,4 @@
-#   Copyright 2024 Open Text
+#   Copyright 2023 Open Text
 #   This program and the accompanying materials
 #   are made available under the terms of the Apache License v2.0 which accompany this distribution.
 #
@@ -89,16 +89,17 @@ flow:
         required: false
         sensitive: true
     - trust_all_roots:
-        default: 'false'
+        default: 'true'
         required: false
     - x_509_hostname_verifier:
-        default: strict
+        default: allow_all
         required: false
     - trust_keystore:
         required: false
     - trust_password:
         required: false
         sensitive: true
+    - nodeport
   workflow:
     - set_kubernetes_host:
         worker_group: '${worker_group}'
@@ -156,7 +157,7 @@ flow:
                 sensitive: true
             - namespace: '${final_namespace}'
             - service_name: '${service_name}'
-            - service_json_body: "${'{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"name\":\"'+service_name+'\"},\"name\":\"'+service_name+'\"},\"spec\":{\"type\":\"LoadBalancer\",\"ports\":[{\"port\":9042,\"nodePort\":31516}],\"selector\":{\"name\":\"'+service_name+'\"}}}'}"
+            - service_json_body: "${'{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"name\":\"'+service_name+'\"},\"name\":\"'+service_name+'\"},\"spec\":{\"type\":\"LoadBalancer\",\"ports\":[{\"port\":9042,\"nodeport\":\"'+nodeport+'\"}],\"selector\":{\"name\":\"'+service_name+'\"}}}'}"
             - worker_group: '${worker_group}'
             - proxy_host: '${proxy_host}'
             - proxy_port: '${proxy_port}'
@@ -170,41 +171,12 @@ flow:
             - trust_password:
                 value: '${trust_password}'
                 sensitive: true
+            - nodeport: '${nodeport}'
         publish:
           - cluster_ip: '${service_cluster_ip}'
         navigate:
           - FAILURE: on_failure
           - SUCCESS: create_pod
-    - create_pod:
-        worker_group:
-          value: '${worker_group}'
-          override: true
-        do:
-          io.cloudslang.kubernetes.create_pod:
-            - kubernetes_provider_sap: '${kubernetes_provider_sap}'
-            - kubernetes_auth_token:
-                value: '${kubernetes_auth_token}'
-                sensitive: true
-            - namespace: '${final_namespace}'
-            - pod_json_body: "${'{\"kind\":\"Pod\",\"spec\":{\"containers\":[{\"name\":\"'+service_name+'\",\"env\":[{\"name\":\"MAX_HEAP_SIZE\",\"value\":\"512M\"},{\"name\":\"HEAP_NEWSIZE\",\"value\":\"100M\"},{\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}},\"name\":\"'+namespace+'\"}],\"image\":\"gcr.io/google_containers/cassandra:v6\",\"args\":[\"/run.sh\"],\"volumeMounts\":[{\"mountPath\":\"/'+service_name+'_data\",\"name\":\"data\"}],\"ports\":[{\"name\":\"cql\",\"containerPort\":9042},{\"name\":\"thrift\",\"containerPort\":9160}],\"resources\":{\"limits\":{\"cpu\":\"0.1\"}}}],\"volumes\":[{\"emptyDir\":{},\"name\":\"data\"}]},\"apiVersion\":\"v1\",\"metadata\":{\"labels\":{\"name\":\"'+service_name+'\"},\"name\":\"'+service_name+'\"}}'}"
-            - worker_group: '${worker_group}'
-            - proxy_host: '${proxy_host}'
-            - proxy_port: '${proxy_port}'
-            - proxy_username: '${proxy_username}'
-            - proxy_password:
-                value: '${proxy_password}'
-                sensitive: true
-            - trust_all_roots: '${trust_all_roots}'
-            - x_509_hostname_verifier: '${x_509_hostname_verifier}'
-            - trust_keystore: '${trust_keystore}'
-            - trust_password:
-                value: '${trust_password}'
-                sensitive: true
-        publish:
-          - pod_name
-        navigate:
-          - FAILURE: on_failure
-          - SUCCESS: create_replication_controller
     - create_replication_controller:
         worker_group:
           value: '${worker_group}'
@@ -310,6 +282,34 @@ flow:
         navigate:
           - SUCCESS: create_namespace
           - FAILURE: on_failure
+    - create_pod:
+        worker_group:
+          value: '${worker_group}'
+          override: true
+        do:
+          io.cloudslang.kubernetes.create_pod:
+            - kubernetes_provider_sap: '${kubernetes_provider_sap}'
+            - kubernetes_auth_token:
+                value: '${kubernetes_auth_token}'
+                sensitive: true
+            - namespace: '${final_namespace}'
+            - pod_json_body: "${'{\"kind\":\"Pod\",\"spec\":{\"containers\":[{\"name\":\"'+service_name+'\",\"env\":[{\"name\":\"MAX_HEAP_SIZE\",\"value\":\"512M\"},{\"name\":\"HEAP_NEWSIZE\",\"value\":\"100M\"},{\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}},\"name\":\"'+namespace+'\"}],\"image\":\"gcr.io/google_containers/cassandra:v6\",\"args\":[\"/run.sh\"],\"volumeMounts\":[{\"mountPath\":\"/'+service_name+'_data\",\"name\":\"data\"}],\"ports\":[{\"name\":\"cql\",\"containerPort\":9042},{\"name\":\"thrift\",\"containerPort\":9160}],\"resources\":{\"limits\":{\"cpu\":\"0.1\"}}}],\"volumes\":[{\"emptyDir\":{},\"name\":\"data\"}]},\"apiVersion\":\"v1\",\"metadata\":{\"labels\":{\"name\":\"'+service_name+'\"},\"name\":\"'+service_name+'\"}}'}"
+            - worker_group: '${worker_group}'
+            - proxy_host: '${proxy_host}'
+            - proxy_port: '${proxy_port}'
+            - proxy_username: '${proxy_username}'
+            - proxy_password:
+                value: '${proxy_password}'
+                sensitive: true
+            - trust_all_roots: '${trust_all_roots}'
+            - x_509_hostname_verifier: '${x_509_hostname_verifier}'
+            - trust_keystore: '${trust_keystore}'
+            - trust_password:
+                value: '${trust_password}'
+                sensitive: true
+        navigate:
+          - FAILURE: on_failure
+          - SUCCESS: create_replication_controller
   outputs:
     - replication_controller_name
     - pod_list


### PR DESCRIPTION
Description:
--

Added nodeport as an input for create_service operation in deploy_cassandra_application flow.

Octane:
--

https://internal.almoctane.com/ui/?p=97002%2F32001&idpId=https%3A%2F%2Fauthenticate.opentext.com%2Fnidp%2Fsaml2%2Fmetadata#/team-backlog/stories

Testing:
--

<img width="1899" height="868" alt="image" src="https://github.com/user-attachments/assets/822b5a49-3e32-43ba-a3dd-69f8cdc0b060" />
<img width="1920" height="897" alt="image" src="https://github.com/user-attachments/assets/44a792c3-f3ae-4b31-8ef9-f350ae0a1a87" />
<img width="1920" height="870" alt="image" src="https://github.com/user-attachments/assets/989b6755-79d2-404b-9ca9-d0b03508d8d0" />
